### PR TITLE
feat: Add invert_status option for SP1/SP2 mapping

### DIFF
--- a/custom_components/nexecur/__init__.py
+++ b/custom_components/nexecur/__init__.py
@@ -169,7 +169,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     }
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    entry.async_on_unload(entry.add_update_listener(_async_update_listener))
     return True
+
+
+async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Reload the entry when its data is updated from the options flow."""
+    await hass.config_entries.async_reload(entry.entry_id)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/nexecur/alarm_control_panel.py
+++ b/custom_components/nexecur/alarm_control_panel.py
@@ -23,6 +23,7 @@ from .const import (
     CONF_ACCOUNT,
     CONF_DISARM_CODE,
     CONF_ARM_CODE,
+    CONF_INVERT_STATUS,
     ALARM_VERSION_VIDEOFIED,
     ALARM_VERSION_HIKVISION,
 )
@@ -77,6 +78,7 @@ class NexecurAlarmEntity(CoordinatorEntity, AlarmControlPanelEntity):
         self._disarm_code = entry.data.get(CONF_DISARM_CODE)
         # Arm code (optional, can be changed anytime)
         self._arm_code = entry.data.get(CONF_ARM_CODE)
+        self._invert_status = entry.data.get(CONF_INVERT_STATUS, False)
 
     @property
     def supported_features(self) -> AlarmControlPanelEntityFeature:
@@ -109,6 +111,14 @@ class NexecurAlarmEntity(CoordinatorEntity, AlarmControlPanelEntity):
         status = int(data.get("panel_status", 0))
         panel_sp1_available = data.get("panel_sp1_available", True)
         panel_sp2_available = data.get("panel_sp2_available", False)
+
+        # Handle inverted status for some Videofied installations
+        if self._invert_status and self._alarm_version == ALARM_VERSION_VIDEOFIED:
+            # Swap status 1 and 2
+            if status == 1:
+                status = 2
+            elif status == 2:
+                status = 1
 
         if status == 0:
             return AlarmControlPanelState.DISARMED

--- a/custom_components/nexecur/config_flow.py
+++ b/custom_components/nexecur/config_flow.py
@@ -158,8 +158,10 @@ class NexecurOptionsFlow(config_entries.OptionsFlow):
             # No arm code - show option
             schema[vol.Required("enable_arm", default="no")] = vol.In(["yes", "no"])
         
-        # Invert status option
-        schema[vol.Required(CONF_INVERT_STATUS, default=invert_status)] = bool
+        # Invert status option (Videofied only)
+        alarm_version = entry_data.get(CONF_ALARM_VERSION, ALARM_VERSION_VIDEOFIED)
+        if alarm_version == ALARM_VERSION_VIDEOFIED:
+            schema[vol.Required(CONF_INVERT_STATUS, default=invert_status)] = bool
 
         return self.async_show_form(
             step_id="init",

--- a/custom_components/nexecur/config_flow.py
+++ b/custom_components/nexecur/config_flow.py
@@ -18,6 +18,7 @@ from .const import (
     CONF_LOGIN_METHOD,
     CONF_DISARM_CODE,
     CONF_ARM_CODE,
+    CONF_INVERT_STATUS,
     ALARM_VERSION_VIDEOFIED,
     ALARM_VERSION_HIKVISION,
     LOGIN_METHOD_PHONE,
@@ -45,6 +46,7 @@ VIDEOFIED_SCHEMA = vol.Schema(
         vol.Optional(CONF_DEVICE_NAME, default="Home Assistant"): str,
         vol.Optional(CONF_DISARM_CODE): str,
         vol.Optional(CONF_ARM_CODE): str,
+        vol.Optional(CONF_INVERT_STATUS, default=False): bool,
     }
 )
 
@@ -95,6 +97,7 @@ class NexecurOptionsFlow(config_entries.OptionsFlow):
         
         disarm_code = entry_data.get(CONF_DISARM_CODE, "")
         arm_code = entry_data.get(CONF_ARM_CODE, "")
+        invert_status = entry_data.get(CONF_INVERT_STATUS, False)
         
         # Determine state
         has_disarm_code = bool(disarm_code)
@@ -129,6 +132,9 @@ class NexecurOptionsFlow(config_entries.OptionsFlow):
             else:
                 new_data.pop(CONF_ARM_CODE, None)
             
+            # Handle invert status
+            new_data[CONF_INVERT_STATUS] = user_input.get(CONF_INVERT_STATUS, False)
+            
             self.hass.config_entries.async_update_entry(self.entry, data=new_data)
             return self.async_create_entry(title="")
 
@@ -151,6 +157,9 @@ class NexecurOptionsFlow(config_entries.OptionsFlow):
         else:
             # No arm code - show option
             schema[vol.Required("enable_arm", default="no")] = vol.In(["yes", "no"])
+        
+        # Invert status option
+        schema[vol.Required(CONF_INVERT_STATUS, default=invert_status)] = bool
 
         return self.async_show_form(
             step_id="init",

--- a/custom_components/nexecur/config_flow.py
+++ b/custom_components/nexecur/config_flow.py
@@ -136,7 +136,7 @@ class NexecurOptionsFlow(config_entries.OptionsFlow):
             new_data[CONF_INVERT_STATUS] = user_input.get(CONF_INVERT_STATUS, False)
             
             self.hass.config_entries.async_update_entry(self.entry, data=new_data)
-            return self.async_create_entry(title="")
+            return self.async_create_entry(title="", data={})
 
         # Build schema based on current state
         schema = {}

--- a/custom_components/nexecur/const.py
+++ b/custom_components/nexecur/const.py
@@ -34,6 +34,7 @@ CONF_DEVICE_NAME = "device_name"
 CONF_LOGIN_METHOD = "login_method"
 CONF_DISARM_CODE = "disarm_code"
 CONF_ARM_CODE = "arm_code"
+CONF_INVERT_STATUS = "invert_status"
 
 # Videofied specific
 CONF_ID_SITE = "id_site"

--- a/custom_components/nexecur/strings.json
+++ b/custom_components/nexecur/strings.json
@@ -16,11 +16,13 @@
           "password": "PIN / Mot de passe",
           "device_name": "Nom de l'appareil",
           "disarm_code": "Code de désactivation (facultatif)",
-          "arm_code": "Code d'activation (facultatif)"
+          "arm_code": "Code d'activation (facultatif)",
+          "invert_status": "Inverser le statut (si SP1/SP2 inversé)"
         },
         "data_desc": {
           "disarm_code": "Une fois défini, ce code ne pourra plus être modifié ou supprimé sans supprimer l'intégration.",
-          "arm_code": "Ce code peut être ajouté ou modifié à tout moment via les options."
+          "arm_code": "Ce code peut être ajouté ou modifié à tout moment via les options.",
+          "invert_status": "Cochez si vos statuts Home et Away sont inversés (SP1=Complet, SP2=Nuit)"
         }
       },
       "hikvision_method": {

--- a/custom_components/nexecur/strings.json
+++ b/custom_components/nexecur/strings.json
@@ -71,7 +71,8 @@
           "arm_code_separate": "Code d'armement (différent)",
           "use_same_code": "Utiliser le même code que désarmement",
           "disarm_info": "État du code de désarmement",
-          "arm_info": "État du code d'armement"
+          "arm_info": "État du code d'armement",
+          "invert_status": "Inverser le statut (si SP1/SP2 inversé)"
         },
         "data_options": {
           "yes": "Oui",

--- a/custom_components/nexecur/translations/en.json
+++ b/custom_components/nexecur/translations/en.json
@@ -16,11 +16,13 @@
           "password": "PIN / Password",
           "device_name": "Device name",
           "disarm_code": "Disarm code (optional)",
-          "arm_code": "Arm code (optional)"
+          "arm_code": "Arm code (optional)",
+          "invert_status": "Invert status (if SP1/SP2 inverted)"
         },
         "data_desc": {
           "disarm_code": "Once set, this code cannot be modified or removed without deleting the integration.",
-          "arm_code": "This code can be added or modified anytime via Options."
+          "arm_code": "This code can be added or modified anytime via Options.",
+          "invert_status": "Check if your Home and Away statuses are inverted (SP1=Full, SP2=Night)"
         }
       },
       "hikvision_method": {
@@ -72,7 +74,8 @@
           "arm_code_separate": "Arm code (different)",
           "use_same_code": "Use same code as disarm",
           "disarm_info": "Disarm code status",
-          "arm_info": "Arm code status"
+          "arm_info": "Arm code status",
+          "invert_status": "Invert status (if SP1/SP2 inverted)"
         },
         "data_options": {
           "yes": "Yes",

--- a/custom_components/nexecur/translations/fr.json
+++ b/custom_components/nexecur/translations/fr.json
@@ -70,7 +70,8 @@
           "arm_code_separate": "Code d'armement (différent)",
           "use_same_code": "Utiliser le même code que désarmement",
           "disarm_info": "État du code de désarmement",
-          "arm_info": "État du code d'armement"
+          "arm_info": "État du code d'armement",
+          "invert_status": "Inverser le statut (si SP1/SP2 inversé)"
         },
         "data_options": {
           "yes": "Oui",

--- a/custom_components/nexecur/translations/fr.json
+++ b/custom_components/nexecur/translations/fr.json
@@ -15,10 +15,14 @@
           "id_site": "ID Site (code de câblage)",
           "password": "PIN / Mot de passe",
           "device_name": "Nom de l'appareil",
-          "disarm_code": "Code de désactivation (facultatif)"
+          "disarm_code": "Code de désactivation (facultatif)",
+          "arm_code": "Code d'activation (facultatif)",
+          "invert_status": "Inverser le statut (si SP1/SP2 inversé)"
         },
         "data_desc": {
-          "disarm_code": "Une fois défini, ce code ne pourra plus être modifié ou supprimé sans supprimer l'intégration."
+          "disarm_code": "Une fois défini, ce code ne pourra plus être modifié ou supprimé sans supprimer l'intégration.",
+          "arm_code": "Ce code peut être ajouté ou modifié à tout moment via les options.",
+          "invert_status": "Cochez si vos statuts Home et Away sont inversés (SP1=Complet, SP2=Nuit)"
         }
       },
       "hikvision_method": {


### PR DESCRIPTION
## Description

Add option to invert SP1/SP2 status mapping for Videofied alarm systems.

Some Videofied installations have inverted status mapping where SP1=Full and SP2=Night instead of the standard SP1=Night and SP2=Full.

This PR adds:
1. CONF_INVERT_STATUS config option
2. Option during initial setup
3. Option in Options flow to change after setup
4. Logic to swap status 1 and 2 when enabled

## Issue

Fixes #10